### PR TITLE
feat(cb2-6588): send trailer id as vrm for trailer tests

### DIFF
--- a/src/utils/extractAmendedBillableTestResults.ts
+++ b/src/utils/extractAmendedBillableTestResults.ts
@@ -1,10 +1,14 @@
 import logger from '../observability/logger';
 import { Differences, DifferencesEntries } from './differences';
-import { TestResultModel, TestType } from './testResult';
+import { TestResultModel, TestType, VehicleType } from './testResult';
 
 export const extractAmendedBillableTestResults = (currentRecord: TestResultModel, previousRecord: TestResultModel) => {
   const testTypeValues = ['testCode'] as const;
-  const testResultValues = ['testStationPNumber', 'vin', 'vrm'] as const;
+  const testResultValues = [
+    'testStationPNumber',
+    'vin',
+    currentRecord.vehicleType === VehicleType.TRL ? 'trailerId' : 'vrm',
+  ] as const;
 
   const fieldsChanged: Differences[] = [];
   currentRecord.testTypes.forEach((currentTestType) => {
@@ -23,7 +27,11 @@ export const extractAmendedBillableTestResults = (currentRecord: TestResultModel
     }
 
     testTypeValues.forEach((field) => fields.push({ fieldName: field, oldValue: previousTestType[field], newValue: currentTestType[field] }));
-    testResultValues.forEach((field) => fields.push({ fieldName: field, oldValue: previousRecord[field], newValue: currentRecord[field] }));
+    testResultValues.forEach((field) => fields.push({
+      fieldName: field === 'trailerId' ? 'vrm' : field,
+      oldValue: previousRecord[field],
+      newValue: currentRecord[field],
+    }));
 
     logger.debug(`Fields changed for testResultId: ${currentRecord.testResultId}: ${JSON.stringify(fields)}`);
 

--- a/src/utils/extractTestResults.ts
+++ b/src/utils/extractTestResults.ts
@@ -2,25 +2,22 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { TestActivity } from './testActivity';
-import { TestResultModel } from './testResult';
+import { TestResultModel, VehicleType } from './testResult';
 
-export const extractBillableTestResults = (record: TestResultModel): TestActivity[] => {
-  const testActivities: TestActivity[] = record.testTypes.map((testType) => ({
-    noOfAxles: record.noOfAxles,
-    testTypeStartTimestamp: record.testStartTimestamp,
-    testTypeEndTimestamp: record.testEndTimestamp,
-    testStationType: record.testStationType,
-    testCode: testType.testCode,
-    vin: record.vin,
-    vrm: record.vrm,
-    testStationPNumber: record.testStationPNumber,
-    testResult: testType.testResult,
-    certificateNumber: testType.certificateNumber,
-    testTypeName: testType.name,
-    vehicleType: record.vehicleType,
-    testerName: record.testerName,
-    testerStaffId: record.testerStaffId,
-    testResultId: record.testResultId,
-  }));
-  return testActivities;
-};
+export const extractBillableTestResults = (record: TestResultModel): TestActivity[] => record.testTypes.map((testType) => ({
+  noOfAxles: record.noOfAxles,
+  testTypeStartTimestamp: record.testStartTimestamp,
+  testTypeEndTimestamp: record.testEndTimestamp,
+  testStationType: record.testStationType,
+  testCode: testType.testCode,
+  vin: record.vin,
+  vrm: record.vehicleType === VehicleType.TRL ? record.trailerId : record.vrm,
+  testStationPNumber: record.testStationPNumber,
+  testResult: testType.testResult,
+  certificateNumber: testType.certificateNumber,
+  testTypeName: testType.name,
+  vehicleType: record.vehicleType,
+  testerName: record.testerName,
+  testerStaffId: record.testerStaffId,
+  testResultId: record.testResultId,
+}));

--- a/src/utils/extractTestResults.ts
+++ b/src/utils/extractTestResults.ts
@@ -1,23 +1,60 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import logger from '../observability/logger';
 import { TestActivity } from './testActivity';
-import { TestResultModel, VehicleType } from './testResult';
+import {
+  ATF_OVERRIDE_TEST_TYPES,
+  OverrideTestStations,
+  TestResultModel,
+  TestStationType,
+  VehicleType,
+} from './testResult';
 
-export const extractBillableTestResults = (record: TestResultModel): TestActivity[] => record.testTypes.map((testType) => ({
-  noOfAxles: record.noOfAxles,
-  testTypeStartTimestamp: record.testStartTimestamp,
-  testTypeEndTimestamp: record.testEndTimestamp,
-  testStationType: record.testStationType,
-  testCode: testType.testCode,
-  vin: record.vin,
-  vrm: record.vehicleType === VehicleType.TRL ? record.trailerId : record.vrm,
-  testStationPNumber: record.testStationPNumber,
-  testResult: testType.testResult,
-  certificateNumber: testType.certificateNumber,
-  testTypeName: testType.name,
-  vehicleType: record.vehicleType,
-  testerName: record.testerName,
-  testerStaffId: record.testerStaffId,
-  testResultId: record.testResultId,
-}));
+export const extractBillableTestResults = (record: TestResultModel, isNonFilteredATF: boolean): TestActivity[] => {
+  const activities: TestActivity[] = [];
+  if (!isNonFilteredATF && process.env.DISABLE_PROCESS_NON_MIGRATED_EVENTS) {
+    logger.debug('Event not sent as non filtered ATF and processing of non-migrated ATFs turned off');
+    return activities;
+  }
+
+  record.testTypes.forEach((testType) => {
+    const testStationPNumber = isNonFilteredATF
+      ? record.testStationPNumber
+      : getOverrideTestStation(record.testStationType, testType.testCode);
+
+    if (testStationPNumber) {
+      activities.push({
+        noOfAxles: record.noOfAxles,
+        testTypeStartTimestamp: record.testStartTimestamp,
+        testTypeEndTimestamp: record.testEndTimestamp,
+        testStationType: record.testStationType,
+        testCode: testType.testCode,
+        vin: record.vin,
+        vrm: record.vehicleType === VehicleType.TRL ? record.trailerId : record.vrm,
+        testStationPNumber,
+        testResult: testType.testResult,
+        certificateNumber: testType.certificateNumber,
+        testTypeName: testType.name,
+        vehicleType: record.vehicleType,
+        testerName: record.testerName,
+        testerStaffId: record.testerStaffId,
+        testResultId: record.testResultId,
+      });
+    }
+  });
+  return activities;
+};
+
+/* eslint-disable consistent-return */
+export function getOverrideTestStation(testStationType: TestStationType, testCode: string): string | undefined {
+  if (testStationType === TestStationType.GVTS) {
+    return OverrideTestStations.GVTS;
+  }
+  if (testStationType === TestStationType.POTF) {
+    return OverrideTestStations.POTF;
+  }
+  if (testStationType === TestStationType.ATF && (ATF_OVERRIDE_TEST_TYPES as readonly string[]).includes(testCode)) {
+    return OverrideTestStations.ATF;
+  }
+}

--- a/src/utils/testResult.ts
+++ b/src/utils/testResult.ts
@@ -3,11 +3,12 @@ export interface TestResultModel {
   noOfAxles: number;
   testStationType: string;
   vin: string;
-  vrm: string;
+  vrm?: string;
+  trailerId?: string;
   testStationPNumber: string;
   testStartTimestamp: string;
   testEndTimestamp: string;
-  vehicleType: string;
+  vehicleType: VehicleType;
   testerStaffId: string;
   testResultId: string;
   testerName: string;
@@ -30,4 +31,13 @@ export interface TestType {
 export enum TypeOfTest {
   CONTINGENCY = 'contingency',
   DESK_BASED = 'desk-based',
+}
+
+export enum VehicleType {
+  PSV = 'psv',
+  HGV = 'hgv',
+  TRL = 'trl',
+  CAR = 'car',
+  LGV = 'lgv',
+  MOTORCYCLE = 'motorcycle',
 }

--- a/src/utils/testResult.ts
+++ b/src/utils/testResult.ts
@@ -1,7 +1,7 @@
 export interface TestResultModel {
   testTypes: TestType[];
   noOfAxles: number;
-  testStationType: string;
+  testStationType: TestStationType;
   vin: string;
   vrm?: string;
   trailerId?: string;
@@ -40,4 +40,42 @@ export enum VehicleType {
   CAR = 'car',
   LGV = 'lgv',
   MOTORCYCLE = 'motorcycle',
+}
+
+export enum OverrideTestStations {
+  GVTS = 'H00313',
+  POTF = 'H00314',
+  ATF = 'P50975',
+}
+
+export const ATF_OVERRIDE_TEST_TYPES = [
+  'art',
+  'arv',
+  'cdv',
+  'cnv',
+  'ddt',
+  'ddv',
+  'drt',
+  'drv',
+  'nft',
+  'nfv',
+  'nnt',
+  'nnv',
+  'npt',
+  'npv',
+  'nvt',
+  'nvv',
+  'tit',
+  'tiv',
+  'trt',
+  'trv',
+  'wbl',
+  'wbs',
+] as const;
+
+export enum TestStationType {
+  ATF = 'atf',
+  GVTS = 'gvts',
+  HQ = 'hq',
+  POTF = 'potf',
 }

--- a/tests/unit/eventHandler.test.ts
+++ b/tests/unit/eventHandler.test.ts
@@ -52,7 +52,7 @@ describe('eventHandler', () => {
     expect(sendEvents).toHaveBeenCalledWith([], EventType.COMPLETION);
     expect(unmarshallSpy).toHaveBeenCalledTimes(1);
     expect(extractBillableTestResults).toHaveBeenCalledTimes(1);
-    expect(extractBillableTestResults).toHaveBeenCalledWith({ testStationPNumber: 'foo' });
+    expect(extractBillableTestResults).toHaveBeenCalledWith({ testStationPNumber: 'foo' }, true);
   });
   it('GIVEN an insert event for a contingency test THEN billable details should be extracted and event sent to eventbridge.', async () => {
     event = {
@@ -80,10 +80,13 @@ describe('eventHandler', () => {
     expect(sendEvents).toHaveBeenCalledWith([], EventType.CONTINGENCY);
     expect(unmarshallSpy).toHaveBeenCalledTimes(1);
     expect(extractBillableTestResults).toHaveBeenCalledTimes(1);
-    expect(extractBillableTestResults).toHaveBeenCalledWith({
-      testStationPNumber: 'foo',
-      typeOfTest: TypeOfTest.CONTINGENCY,
-    });
+    expect(extractBillableTestResults).toHaveBeenCalledWith(
+      {
+        testStationPNumber: 'foo',
+        typeOfTest: TypeOfTest.CONTINGENCY,
+      },
+      true,
+    );
   });
   it('GIVEN an modify event THEN billable details should be extracted and event sent to eventbridge.', async () => {
     event = {
@@ -141,11 +144,11 @@ describe('eventHandler', () => {
     expect(extractBillableTestResults).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(`error: Unhandled event {event: foo}${EOL}`);
   });
-  it('GIVEN a handled event WHEN the event is sent as an unfiltered atf THEN a debug message is logged to the console', async () => {
-    event = ({
+  it('GIVEN a MODIFY event WHEN the event is sent as an unfiltered atf THEN a debug message is logged to the console', async () => {
+    event = {
       Records: [
         {
-          eventName: 'foo',
+          eventName: 'MODIFY',
           dynamodb: {
             NewImage: {
               testStationPNumber: {
@@ -160,14 +163,33 @@ describe('eventHandler', () => {
           },
         },
       ],
-    } as unknown) as DynamoDBStreamEvent;
+    } as DynamoDBStreamEvent;
     // @ts-ignore
     const consoleSpy = jest.spyOn(console._stdout, 'write');
     await eventHandler(event);
     expect(sendEvents).not.toHaveBeenCalled();
     expect(extractAmendedBillableTestResults).not.toHaveBeenCalled();
-    expect(extractBillableTestResults).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(`debug: Event not sent as non filtered ATF${EOL}`);
+  });
+
+  it('GIVEN a INSERT event WHEN the event is sent as an unfiltered atf THEN extractBillableTestResults is called with `isNonFilteredATF` set to false', async () => {
+    event = {
+      Records: [
+        {
+          eventName: 'INSERT',
+          dynamodb: {
+            NewImage: {
+              testStationPNumber: {
+                S: 'bar',
+              },
+            },
+          },
+        },
+      ],
+    } as DynamoDBStreamEvent;
+    await eventHandler(event);
+    expect(extractAmendedBillableTestResults).not.toHaveBeenCalled();
+    expect(extractBillableTestResults).toHaveBeenCalledWith({ testStationPNumber: 'bar' }, false);
   });
 });
 

--- a/tests/unit/extractTestResults.test.ts
+++ b/tests/unit/extractTestResults.test.ts
@@ -2,9 +2,15 @@
 /* eslint-disable @typescript-eslint/indent */
 /* eslint-disable @typescript-eslint/quotes */
 /* eslint-disable quote-props */
-import { extractBillableTestResults } from '../../src/utils/extractTestResults';
+import { extractBillableTestResults, getOverrideTestStation } from '../../src/utils/extractTestResults';
 import { TestActivity } from '../../src/utils/testActivity';
-import { TestResultModel, VehicleType } from '../../src/utils/testResult';
+import {
+  ATF_OVERRIDE_TEST_TYPES,
+  OverrideTestStations,
+  TestResultModel,
+  TestStationType,
+  VehicleType,
+} from '../../src/utils/testResult';
 
 describe('extractTestResults', () => {
   let TEST_ACTIVITY: TestActivity[];
@@ -12,7 +18,7 @@ describe('extractTestResults', () => {
   it(`GIVEN data WITHOUT a certificate number issued WHEN the test result is extracted into an event THEN the event doesn't have a certificate number`, () => {
     const mockRecord: TestResultModel = {
       noOfAxles: 2,
-      testStationType: 'gvts',
+      testStationType: TestStationType.GVTS,
       testEndTimestamp: '2019-01-14T10:36:33.987Z',
       testStartTimestamp: '2019-01-14T10:36:33.987Z',
       vin: 'XMGDE02FS0H012303',
@@ -35,7 +41,7 @@ describe('extractTestResults', () => {
         },
       ],
     };
-    TEST_ACTIVITY = extractBillableTestResults(mockRecord);
+    TEST_ACTIVITY = extractBillableTestResults(mockRecord, true);
     const EXPECTED_TEST_ACTIVITY: TestActivity = {
       noOfAxles: 2,
       testTypeStartTimestamp: '2019-01-14T10:36:33.987Z',
@@ -59,7 +65,7 @@ describe('extractTestResults', () => {
   it('GIVEN data WITH a certificate number issued WHEN the test result is extracted into an event THEN the event has certificate number', () => {
     const mockRecord: TestResultModel = {
       noOfAxles: 2,
-      testStationType: 'gvts',
+      testStationType: TestStationType.GVTS,
       testEndTimestamp: '2019-01-14T10:36:33.987Z',
       testStartTimestamp: '2019-01-14T10:36:33.987Z',
       vin: 'XMGDE02FS0H012303',
@@ -84,7 +90,7 @@ describe('extractTestResults', () => {
         },
       ],
     };
-    TEST_ACTIVITY = extractBillableTestResults(mockRecord);
+    TEST_ACTIVITY = extractBillableTestResults(mockRecord, true);
     const EXPECTED_TEST_ACTIVITY: TestActivity = {
       noOfAxles: 2,
       testTypeStartTimestamp: '2019-01-14T10:36:33.987Z',
@@ -108,7 +114,7 @@ describe('extractTestResults', () => {
   it('GIVEN data with two test types WHEN test results are extracted into events THEN expect two events to be generated', () => {
     const mockRecord: TestResultModel = {
       noOfAxles: 2,
-      testStationType: 'gvts',
+      testStationType: TestStationType.GVTS,
       testEndTimestamp: 'foo',
       testStartTimestamp: 'bar',
       vin: 'XMGDE02FS0H012303',
@@ -142,13 +148,13 @@ describe('extractTestResults', () => {
         },
       ],
     };
-    TEST_ACTIVITY = extractBillableTestResults(mockRecord);
+    TEST_ACTIVITY = extractBillableTestResults(mockRecord, true);
     expect(TEST_ACTIVITY).toHaveLength(2);
   });
   it('GIVEN a trailer test result WHEN the test result is extracted into an event THEN the event has the tailer id in the vrm field', () => {
     const mockRecord: TestResultModel = {
       noOfAxles: 2,
-      testStationType: 'gvts',
+      testStationType: TestStationType.GVTS,
       testEndTimestamp: '2019-01-14T10:36:33.987Z',
       testStartTimestamp: '2019-01-14T10:36:33.987Z',
       vin: 'XMGDE02FS0H012303',
@@ -172,7 +178,7 @@ describe('extractTestResults', () => {
         },
       ],
     };
-    TEST_ACTIVITY = extractBillableTestResults(mockRecord);
+    TEST_ACTIVITY = extractBillableTestResults(mockRecord, true);
     const EXPECTED_TEST_ACTIVITY: TestActivity = {
       noOfAxles: 2,
       testTypeStartTimestamp: '2019-01-14T10:36:33.987Z',
@@ -192,5 +198,206 @@ describe('extractTestResults', () => {
     };
     expect(TEST_ACTIVITY[0].vrm).toEqual(mockRecord.trailerId);
     expect(TEST_ACTIVITY).toContainEqual(EXPECTED_TEST_ACTIVITY);
+  });
+
+  const testCases = [
+    {
+      testStationType: TestStationType.GVTS,
+      testStationPNumber: OverrideTestStations.GVTS,
+      testCode: 'not a valid test code',
+    },
+    {
+      testStationType: TestStationType.ATF,
+      testStationPNumber: OverrideTestStations.ATF,
+      testCode: ATF_OVERRIDE_TEST_TYPES[0],
+    },
+    {
+      testStationType: TestStationType.POTF,
+      testStationPNumber: OverrideTestStations.POTF,
+      testCode: 'not a valid test code',
+    },
+  ];
+  it.each(testCases)(
+    'GIVEN data WHEN the test station is not present in the secrets and the toggle is not defined THEN the test station number is changed',
+    (testCase) => {
+      const { testStationType, testStationPNumber, testCode } = testCase;
+      process.env.DISABLE_PROCESS_NON_MIGRATED_EVENTS = '';
+      const mockRecord: TestResultModel = {
+        noOfAxles: 2,
+        testStationType,
+        testEndTimestamp: '2019-01-14T10:36:33.987Z',
+        testStartTimestamp: '2019-01-14T10:36:33.987Z',
+        vin: 'XMGDE02FS0H012303',
+        vrm: 'JY58FPP',
+        testerStaffId: '2',
+        testStationPNumber: 'P99005',
+        vehicleType: VehicleType.PSV,
+        trailerId: 'PSV123',
+        testResultId: '9',
+        testerName: 'Dorel',
+        testStatus: 'submitted',
+        testTypes: [
+          {
+            certificateNumber: '1234',
+            testCode,
+            testTypeId: '1',
+            testResult: 'fail',
+            testTypeEndTimeStamp: '2019-01-14T10:36:33.987Z',
+            testTypeStartTimeStamp: '2019-01-14T10:36:33.987Z',
+            name: 'Annual test',
+            testNumber: 'W084564',
+          },
+        ],
+      };
+      TEST_ACTIVITY = extractBillableTestResults(mockRecord, false);
+      const EXPECTED_TEST_ACTIVITY: TestActivity = {
+        noOfAxles: 2,
+        testTypeStartTimestamp: '2019-01-14T10:36:33.987Z',
+        testTypeEndTimestamp: '2019-01-14T10:36:33.987Z',
+        testStationType,
+        testCode,
+        vin: 'XMGDE02FS0H012303',
+        vrm: 'JY58FPP',
+        testStationPNumber,
+        testResult: 'fail',
+        certificateNumber: '1234',
+        testTypeName: 'Annual test',
+        vehicleType: 'psv',
+        testerName: 'Dorel',
+        testerStaffId: '2',
+        testResultId: '9',
+      };
+      expect(TEST_ACTIVITY).toContainEqual(EXPECTED_TEST_ACTIVITY);
+    },
+  );
+  it.each(testCases)(
+    'GIVEN data WHEN the test station is not present in the secrets and the toggle is defined THEN the events are not sent',
+    (testCase) => {
+      const { testStationType, testCode } = testCase;
+      process.env.DISABLE_PROCESS_NON_MIGRATED_EVENTS = 'defined';
+      const mockRecord: TestResultModel = {
+        noOfAxles: 2,
+        testStationType,
+        testEndTimestamp: '2019-01-14T10:36:33.987Z',
+        testStartTimestamp: '2019-01-14T10:36:33.987Z',
+        vin: 'XMGDE02FS0H012303',
+        vrm: 'JY58FPP',
+        testerStaffId: '2',
+        testStationPNumber: 'P99005',
+        vehicleType: VehicleType.PSV,
+        trailerId: 'PSV123',
+        testResultId: '9',
+        testerName: 'Dorel',
+        testStatus: 'submitted',
+        testTypes: [
+          {
+            certificateNumber: '1234',
+            testCode,
+            testTypeId: '1',
+            testResult: 'fail',
+            testTypeEndTimeStamp: '2019-01-14T10:36:33.987Z',
+            testTypeStartTimeStamp: '2019-01-14T10:36:33.987Z',
+            name: 'Annual test',
+            testNumber: 'W084564',
+          },
+        ],
+      };
+      TEST_ACTIVITY = extractBillableTestResults(mockRecord, false);
+      expect(TEST_ACTIVITY).toHaveLength(0);
+    },
+  );
+  it('GIVEN data WHEN the test station is not present in the secrets AND the toggle is not defined AND the test station is an ATF AND the test code is not in the list THEN activity is not generated', () => {
+    process.env.DISABLE_PROCESS_NON_MIGRATED_EVENTS = '';
+    const mockRecord: TestResultModel = {
+      noOfAxles: 2,
+      testStationType: TestStationType.ATF,
+      testEndTimestamp: '2019-01-14T10:36:33.987Z',
+      testStartTimestamp: '2019-01-14T10:36:33.987Z',
+      vin: 'XMGDE02FS0H012303',
+      vrm: 'JY58FPP',
+      testerStaffId: '2',
+      testStationPNumber: 'P99005',
+      vehicleType: VehicleType.PSV,
+      trailerId: 'PSV123',
+      testResultId: '9',
+      testerName: 'Dorel',
+      testStatus: 'submitted',
+      testTypes: [
+        {
+          certificateNumber: '1234',
+          testCode: 'not a valid test code',
+          testTypeId: '1',
+          testResult: 'fail',
+          testTypeEndTimeStamp: '2019-01-14T10:36:33.987Z',
+          testTypeStartTimeStamp: '2019-01-14T10:36:33.987Z',
+          name: 'Annual test',
+          testNumber: 'W084564',
+        },
+      ],
+    };
+    TEST_ACTIVITY = extractBillableTestResults(mockRecord, false);
+    expect(TEST_ACTIVITY).toHaveLength(0);
+  });
+  it('GIVEN data WHEN the test station is not present in the secrets AND the toggle is not defined AND the test station is an ATF AND one test code is in the list and one is not THEN only one activity is generated', () => {
+    process.env.DISABLE_PROCESS_NON_MIGRATED_EVENTS = '';
+    const mockRecord: TestResultModel = {
+      noOfAxles: 2,
+      testStationType: TestStationType.ATF,
+      testEndTimestamp: '2019-01-14T10:36:33.987Z',
+      testStartTimestamp: '2019-01-14T10:36:33.987Z',
+      vin: 'XMGDE02FS0H012303',
+      vrm: 'JY58FPP',
+      testerStaffId: '2',
+      testStationPNumber: 'P99005',
+      vehicleType: VehicleType.PSV,
+      trailerId: 'PSV123',
+      testResultId: '9',
+      testerName: 'Dorel',
+      testStatus: 'submitted',
+      testTypes: [
+        {
+          certificateNumber: '1234',
+          testCode: 'not a valid test code',
+          testTypeId: '1',
+          testResult: 'fail',
+          testTypeEndTimeStamp: '2019-01-14T10:36:33.987Z',
+          testTypeStartTimeStamp: '2019-01-14T10:36:33.987Z',
+          name: 'Annual test',
+          testNumber: 'W084564',
+        },
+        {
+          certificateNumber: '1234',
+          testCode: ATF_OVERRIDE_TEST_TYPES[0],
+          testTypeId: '1',
+          testResult: 'fail',
+          testTypeEndTimeStamp: '2019-01-14T10:36:33.987Z',
+          testTypeStartTimeStamp: '2019-01-14T10:36:33.987Z',
+          name: 'Annual test',
+          testNumber: 'W084564',
+        },
+      ],
+    };
+    TEST_ACTIVITY = extractBillableTestResults(mockRecord, false);
+    expect(TEST_ACTIVITY).toHaveLength(1);
+    expect(TEST_ACTIVITY[0].testStationPNumber).toEqual(OverrideTestStations.ATF);
+  });
+});
+
+describe('getOverrideTestStation', () => {
+  it('GIVEN an GVTS test station THEN it returns the GTVS test station P Number', () => {
+    expect(getOverrideTestStation(TestStationType.GVTS, 'foo')).toBe(OverrideTestStations.GVTS);
+  });
+  it('GIVEN an POTF test station THEN it returns the POTF test station P Number', () => {
+    expect(getOverrideTestStation(TestStationType.POTF, 'foo')).toBe(OverrideTestStations.POTF);
+  });
+
+  it('GIVEN an ATF test station AND the test code is in the test codes to override THEN it returns the ATF test station P Number', () => {
+    expect(getOverrideTestStation(TestStationType.ATF, ATF_OVERRIDE_TEST_TYPES[0])).toBe(OverrideTestStations.ATF);
+  });
+  it('GIVEN an ATF test station AND the test code is not in the test codes to override THEN it returns undefined', () => {
+    expect(getOverrideTestStation(TestStationType.ATF, 'Not a valid test code')).toBeUndefined();
+  });
+  it('GIVEN an unknown test station type THEN it returns undefined', () => {
+    expect(getOverrideTestStation(('foobar' as unknown) as TestStationType, 'foo')).toBeUndefined();
   });
 });

--- a/tests/unit/extractTestResults.test.ts
+++ b/tests/unit/extractTestResults.test.ts
@@ -4,7 +4,7 @@
 /* eslint-disable quote-props */
 import { extractBillableTestResults } from '../../src/utils/extractTestResults';
 import { TestActivity } from '../../src/utils/testActivity';
-import { TestResultModel } from '../../src/utils/testResult';
+import { TestResultModel, VehicleType } from '../../src/utils/testResult';
 
 describe('extractTestResults', () => {
   let TEST_ACTIVITY: TestActivity[];
@@ -19,7 +19,7 @@ describe('extractTestResults', () => {
       vrm: 'JY58FPP',
       testerStaffId: '2',
       testStationPNumber: 'P99005',
-      vehicleType: 'psv',
+      vehicleType: VehicleType.PSV,
       testResultId: '9',
       testerName: 'Dorel',
       testStatus: 'submitted',
@@ -52,6 +52,7 @@ describe('extractTestResults', () => {
       testerStaffId: '2',
       testResultId: '9',
     };
+    expect(TEST_ACTIVITY[0].vrm).not.toEqual(mockRecord.trailerId);
     expect(TEST_ACTIVITY).toContainEqual(EXPECTED_TEST_ACTIVITY);
   });
 
@@ -65,7 +66,8 @@ describe('extractTestResults', () => {
       vrm: 'JY58FPP',
       testerStaffId: '2',
       testStationPNumber: 'P99005',
-      vehicleType: 'psv',
+      vehicleType: VehicleType.PSV,
+      trailerId: 'PSV123',
       testResultId: '9',
       testerName: 'Dorel',
       testStatus: 'submitted',
@@ -113,7 +115,7 @@ describe('extractTestResults', () => {
       vrm: 'JY58FPP',
       testerStaffId: '2',
       testStationPNumber: 'P99005',
-      vehicleType: 'psv',
+      vehicleType: VehicleType.PSV,
       testResultId: '9',
       testerName: 'Dorel',
       testStatus: 'submitted',
@@ -142,5 +144,53 @@ describe('extractTestResults', () => {
     };
     TEST_ACTIVITY = extractBillableTestResults(mockRecord);
     expect(TEST_ACTIVITY).toHaveLength(2);
+  });
+  it('GIVEN a trailer test result WHEN the test result is extracted into an event THEN the event has the tailer id in the vrm field', () => {
+    const mockRecord: TestResultModel = {
+      noOfAxles: 2,
+      testStationType: 'gvts',
+      testEndTimestamp: '2019-01-14T10:36:33.987Z',
+      testStartTimestamp: '2019-01-14T10:36:33.987Z',
+      vin: 'XMGDE02FS0H012303',
+      trailerId: 'TRL123',
+      testerStaffId: '2',
+      testStationPNumber: 'P99005',
+      vehicleType: VehicleType.TRL,
+      testResultId: '9',
+      testerName: 'Dorel',
+      testStatus: 'submitted',
+      testTypes: [
+        {
+          certificateNumber: '1234',
+          testCode: 'aas',
+          testTypeId: '1',
+          testResult: 'fail',
+          testTypeEndTimeStamp: '2019-01-14T10:36:33.987Z',
+          testTypeStartTimeStamp: '2019-01-14T10:36:33.987Z',
+          name: 'Annual test',
+          testNumber: 'W084564',
+        },
+      ],
+    };
+    TEST_ACTIVITY = extractBillableTestResults(mockRecord);
+    const EXPECTED_TEST_ACTIVITY: TestActivity = {
+      noOfAxles: 2,
+      testTypeStartTimestamp: '2019-01-14T10:36:33.987Z',
+      testTypeEndTimestamp: '2019-01-14T10:36:33.987Z',
+      testStationType: 'gvts',
+      testCode: 'aas',
+      vin: 'XMGDE02FS0H012303',
+      vrm: 'TRL123',
+      testStationPNumber: 'P99005',
+      testResult: 'fail',
+      certificateNumber: '1234',
+      testTypeName: 'Annual test',
+      vehicleType: 'trl',
+      testerName: 'Dorel',
+      testerStaffId: '2',
+      testResultId: '9',
+    };
+    expect(TEST_ACTIVITY[0].vrm).toEqual(mockRecord.trailerId);
+    expect(TEST_ACTIVITY).toContainEqual(EXPECTED_TEST_ACTIVITY);
   });
 });


### PR DESCRIPTION
## Send trailer id for trailer tests
Send trailer Id instead of vrm for trailer tests. Sending trailer id in the vrm field. Dependant on https://github.com/dvsa/cvs-tsk-pull-test-results/pull/39
[CB2-6871](https://dvsa.atlassian.net/browse/CB2-6871)
[CB2-6588](https://dvsa.atlassian.net/browse/CB2-6588)

## Checklist
- [ ] Code has been tested manually
- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Squashed commit contains the JIRA ticket number